### PR TITLE
Preserve environmental variables in Path

### DIFF
--- a/PSPath.psd1
+++ b/PSPath.psd1
@@ -1,6 +1,6 @@
 @{
 RootModule = 'PSPath.psm1'
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.1'
 GUID = '43d1ccde-b82b-4b4b-8ad3-386bf707e94b'
 Author = 'Eduardo Antunes C. de Sousa'
 Description = 'Path Environment Manipuation Functions'
@@ -12,5 +12,6 @@ HelpInfoURI = 'https://github.com/ecsousa/PSPath'
 PrivateData = @{
         Tags='Path'
         ProjectUri='https://github.com/ecsousa/PSPath'
+        ReleaseNotes = 'Respect the environmental variables in the Path as stored in the registry as a ExpandString.'
     }
 }

--- a/PSPath.psm1
+++ b/PSPath.psm1
@@ -36,8 +36,11 @@ function Add-Path {
     else {
         $regPath = 'HKCU:\Environment';
     }
-
-    $currentPath = (Get-ItemProperty $regPath).PATH;
+    
+    # Need to preserve the DOS style environmental variables like %USERPROFILE% because PATH is stored in the registry as an ExpandString.  
+    # Otherwise when read, appended, and set the env vars will have been expanded and the original values lost. 
+    # The '$false' is the DefaultValue, which is what what would be returned if the property 'PATH' does not exist.
+    $currentPath = (Get-Item -Path $regPath).GetValue('Path', $false, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
 
     if($currentPath) {
         $newPath = "$currentPath;$path";
@@ -50,5 +53,4 @@ function Add-Path {
 
     Update-Path
 }
-
 


### PR DESCRIPTION
Path is stored as an ExpandString in the registry, so when appending new paths, the raw value has to be extracted first.
